### PR TITLE
fix missing class in restore qemu

### DIFF
--- a/modules/qemu/lib/onboard/virtualization/qemu.rb
+++ b/modules/qemu/lib/onboard/virtualization/qemu.rb
@@ -1,6 +1,7 @@
 require 'yaml'
 require 'uuid'
 require 'fileutils'
+require 'sinatra/base'  # Sinatra types in YAML such as IndifferentHash
 
 require 'onboard/constants'
 require 'onboard/extensions/process'


### PR DESCRIPTION
See also https://www.rubydoc.info/gems/sinatra/Sinatra/IndifferentHash.