### PR TITLE
fix NGINX reverse proxy headers

### DIFF
--- a/doc/sysadm/examples/etc/nginx/sites-available/margay
+++ b/doc/sysadm/examples/etc/nginx/sites-available/margay
@@ -56,12 +56,26 @@ server {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
-		
+
 		# Reverse proxy to Sinatra
 		location / {
 		    proxy_pass http://localhost:4567/;
+
+			# https://linuxize.com/post/nginx-reverse-proxy/
+
+			proxy_http_version  1.1;
+			proxy_cache_bypass  $http_upgrade;
+
+			proxy_set_header Upgrade           $http_upgrade;
+			proxy_set_header Connection        "upgrade";
+			proxy_set_header Host              $host;
+			proxy_set_header X-Real-IP         $remote_addr;
+			proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_set_header X-Forwarded-Host  $host;
+			proxy_set_header X-Forwarded-Port  $server_port;
 		}
-		
+
 	}
 
 	# deny access to .htaccess files, if Apache's document root

--- a/modules/qemu/views/virtualization/qemu/vm.html.erb
+++ b/modules/qemu/views/virtualization/qemu/vm.html.erb
@@ -10,6 +10,8 @@
   all_bridges         = all_netifs.select     { |i| i.bridge? }  
   all_running_ifnames = all_netifs.map        { |i| i.name    }        
 
+  # Please make sure a possible reverse proxy does set X-Forwarded-Host -- https://linuxize.com/post/nginx-reverse-proxy/
+  # Sinatra/Rack's request.host reads it, if present.
   vnc_uri             = ( 
       "vnc://#{request.host}#{vm.config['-vnc']}" if vm.config['-vnc'] =~ /\d/ )
   spice_uri           = ( 


### PR DESCRIPTION
It was spotted in generating SPICE/VNC URLs in QEMU, they showed 'localhost' instead of e.g. '192.168.x.y'